### PR TITLE
fix(core): stop must_contain/must_startswith returning True for geo variables

### DIFF
--- a/gixy/core/variable.py
+++ b/gixy/core/variable.py
@@ -201,6 +201,7 @@ class Variable(object):
         # If the value is a list (hash block), check all values
         if isinstance(self.value, list):
             # Ensure that every map value must contain the char
+            evaluated = False
             for var in self.value:
                 if (
                     not isinstance(var, Variable)
@@ -221,8 +222,9 @@ class Variable(object):
                         break
                 if not found_must_contain:  # A map value doesn't need to contain the char, therefore return False
                     return False
+                evaluated = True
 
-            return True
+            return evaluated
 
         # Otherwise checks literal
         return self.value and char in self.value
@@ -249,6 +251,7 @@ class Variable(object):
 
         # If the value is a list (hash block), check all values
         if isinstance(self.value, list):
+            evaluated = False
             for var in self.value:
                 if (
                     not isinstance(var, Variable)
@@ -264,8 +267,9 @@ class Variable(object):
                 )
                 if not compiled_val or not compiled_val[0].must_startswith(char):
                     return False
+                evaluated = True
 
-            return True
+            return evaluated
 
         # Otherwise checks literal
         return self.value and self.value[0] == char

--- a/tests/plugins/simply/ssrf/geo_var_arg.conf
+++ b/tests/plugins/simply/ssrf/geo_var_arg.conf
@@ -1,0 +1,13 @@
+http {
+    geo $prefix {
+        default "x";
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://$prefix$arg_host;
+        }
+    }
+}

--- a/tests/plugins/simply/ssrf/geo_var_fp.conf
+++ b/tests/plugins/simply/ssrf/geo_var_fp.conf
@@ -1,0 +1,13 @@
+http {
+    geo $prefix {
+        default "x";
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://$prefix;
+        }
+    }
+}


### PR DESCRIPTION
In the list-valued branch of `Variable.must_contain` and `Variable.must_startswith`, entries whose provider is not a `map`-block `MapDirective` are skipped — so every `geo` block entry is skipped and the loop falls through to `return True`. That inverts the contract: `geo $prefix { default "x"; }` with `proxy_pass http://$prefix$arg_host;` made the ssrf plugin see `must_contain("/") == True` and return early, hiding the attacker-controlled `$arg_host` (false negative).

The fix tracks whether at least one entry was actually evaluated and returns False when none were.

Tests: new ssrf simply cases (`geo_var_arg.conf` positive, `geo_var_fp.conf` false-positive); full suite passes.

AI disclosure: written with Claude Code, reviewed by me.